### PR TITLE
Checkout track and pull remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 [//]: # "For new features that got added"
-- 
+- Add `track` option to checkout command to checkout upstream branches.
 
 ### Changed
 [//]: # "For behavior that has been changed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 [//]: # "3. Remove the unused sections from the new release."
 [//]: # "4. Update the comparison link for the unreleased header to the new tag."
 
-## [Unreleased](https://github.com/lumicks/doltcli/compare/fd79aa2bd0076dad5298f9414dff47af7d7068f5...HEAD)
+## [Unreleased](https://github.com/lumicks/doltcli/compare/v0.1.18...HEAD)
 
 [//]: # "When adding an entry please also add a link to the"
 [//]: # "corresponding pull request that introduce the change"
@@ -20,13 +20,12 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 
 ### Added
 [//]: # "For new features that got added"
-- Add `track` option to checkout command to checkout upstream branches.
-- Add optional `branch` argument to `pull` operation.
+- 
 
 ### Changed
 [//]: # "For behavior that has been changed"
 [//]: # "(should ideally result in a new semantic version if that scheme is being used)"
-- Changed the Github actions to our standard ones
+- 
 
 ### Deprecated
 [//]: # "For features for which it has been decided that they should be removed in the future"
@@ -45,4 +44,18 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 [//]: # "In case of security problems that have been discovered and end-users should fix"
 -
 
-## [v0.0.0](https://github.com/lumicks/{{project_name}}/releases/tag/v0.0.0) - 2023-01-01
+## [Unreleased](https://github.com/lumicks/doltcli/releases/tag/v0.1.18) - 2023-01-24
+
+[//]: # "When adding an entry please also add a link to the"
+[//]: # "corresponding pull request that introduce the change"
+
+
+### Added
+[//]: # "For new features that got added"
+- Add `track` option to checkout command to checkout upstream branches.
+- Add optional `branch` argument to `pull` operation.
+
+### Changed
+[//]: # "For behavior that has been changed"
+[//]: # "(should ideally result in a new semantic version if that scheme is being used)"
+- Changed the Github actions to our standard ones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This document follows the conventions laid out in [Keep a CHANGELOG](https://kee
 ### Added
 [//]: # "For new features that got added"
 - Add `track` option to checkout command to checkout upstream branches.
+- Add optional `branch` argument to `pull` operation.
 
 ### Changed
 [//]: # "For behavior that has been changed"

--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -807,6 +807,7 @@ class Dolt(DoltT):
         tables: Optional[Union[str, List[str]]] = None,
         checkout_branch: bool = False,
         start_point: Optional[str] = None,
+        track: Optional[str] = None,
         **kwargs,
     ):
         """
@@ -816,6 +817,7 @@ class Dolt(DoltT):
         :param tables: table or tables to checkout
         :param checkout_branch: branch to checkout
         :param start_point: tip of new branch
+        :param track: the upstream branch to track
         :return:
         """
         if tables and branch:
@@ -831,6 +833,10 @@ class Dolt(DoltT):
 
         if tables:
             args.append(" ".join(to_list(tables)))
+
+        if track is not None:
+            args.append("--track")
+            args.append(track)
 
         self.execute(args, **kwargs)
 

--- a/doltcli/dolt.py
+++ b/doltcli/dolt.py
@@ -918,13 +918,18 @@ class Dolt(DoltT):
         # just print the output
         self.execute(args, **kwargs)
 
-    def pull(self, remote: str = "origin", **kwargs):
+    def pull(self, remote: str = "origin", branch: Optional[str] = None, **kwargs):
         """
         Pull the latest changes from the specified remote.
-        :param remote:
+        :param remote: The remote to pull the changes from
+        :param branch: The branch on the remote to pull the changes from
         :return:
         """
-        self.execute(["pull", remote], **kwargs)
+        args = ["pull", remote]
+        if branch is not None:
+            args.append(branch)
+
+        self.execute(args, **kwargs)
 
     def fetch(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lumicks-doltcli"
-version = "0.1.17"
+version = "0.1.18"
 license = {file = "LICENSE"}
 description = "Slim Python interface for Dolt's CLI API."
 authors = [


### PR DESCRIPTION
Adds the option to checkout a branch on a remote and set up the upstream configuration for it. Also adds the option to specify the branch when performing a remote pull.